### PR TITLE
Remove non-existing getId() function call

### DIFF
--- a/Cron/PriceListCron.php
+++ b/Cron/PriceListCron.php
@@ -500,7 +500,7 @@ class PriceListCron implements PriceListCronInterface
         $code = $this->getGroupCode($priceList, $taxClassGroup);
 
         /** @var Group $group */
-        $group = $this->customerGroupRepository->getById($group->getId());
+        $group = $this->customerGroupRepository->getById($group->id);
         $group->setCode($code);
         $group->setTaxClassId($taxClassGroup->getClassId());
 


### PR DESCRIPTION
The Dealer4Dealer/CustomerGroup model does not have a getId() function.

Alternatively you could create the missing getId() function.