### PR TITLE
Fix bug where getCustomAttribute returns null

### DIFF
--- a/Observer/Catalog/Product/SaveAfter.php
+++ b/Observer/Catalog/Product/SaveAfter.php
@@ -65,7 +65,7 @@ class SaveAfter implements ObserverInterface
 
         $this->itemGroupAttributeCode = $this->helper->getItemConfig(ItemConfig::ITEMGROUP_ATTRIBUTE_CODE);
 
-        $this->itemGroup = $product->getCustomAttribute($this->itemGroupAttributeCode)->getValue();
+        $this->itemGroup = $product->getCustomAttribute($this->itemGroupAttributeCode) ? $product->getCustomAttribute($this->itemGroupAttributeCode)->getValue() : null;
 
         //Check if the item group has changed on the product
         if (is_null($this->itemGroup) || ($this->itemGroup === $product->getOrigData()[$this->itemGroupAttributeCode])) {


### PR DESCRIPTION
Call to a member function getValue() on null at vendor/dealer4dealer/pricelist-magento2/Observer/Catalog/Product/SaveAfter.php:70