### PR TITLE
Update PriceListCron.php to be compatible with PHP8.3.

### DIFF
--- a/Cron/PriceListCron.php
+++ b/Cron/PriceListCron.php
@@ -68,6 +68,7 @@ class PriceListCron implements PriceListCronInterface
      */
     private $productTierPriceFactory;
     private $productRepository;
+    private $groupManagement;
     // Variables for updating the tier prices with the aftersave from a product
     private $updateSingleProductSku = null;
     /** @var ?PriceListItemGroupInterface[] $priceListItemGroupsToAdd */


### PR DESCRIPTION
The creation of dynamic properties is deprecated in PHP8.3. This pull request solves the following error: Deprecated Functionality: Creation of dynamic property Dealer4dealer\Pricelist\Cron\PriceListCron::$groupManagement is deprecated.